### PR TITLE
Support multiple ad units from NativeX

### DIFF
--- a/packages/directory/components/facets.marko
+++ b/packages/directory/components/facets.marko
@@ -1,5 +1,5 @@
 import { getAsArray } from "@base-cms/object-path";
-import findActiveFacet from './find-active-facet';
+import findActiveFacet from "./find-active-facet";
 
 $ const facets = getAsArray(input, "facets");
 $ const activeFacet = findActiveFacet(facets, input.activeId);

--- a/packages/leaders/components/all.marko
+++ b/packages/leaders/components/all.marko
@@ -14,7 +14,7 @@ $ const enabled = defaultValue(site.get("leaders.enabled"), false);
     offsetTop: site.get("leaders.offsetTop", 105),
     promotionLimit: site.get("leaders.promotionLimit", 3),
     videoLimit: site.get("leaders.videoLimit", 2),
-    viewAllHref: '/leaders',
+    viewAllHref: "/leaders",
     mediaQueries: [
       { prop: "columns", value: 2, query: "(max-width: 991px)" },
       { prop: "columns", value: 1, query: "(max-width: 700px)" },

--- a/packages/leaders/components/contextual.marko
+++ b/packages/leaders/components/contextual.marko
@@ -14,7 +14,7 @@ $ const enabled = defaultValue(site.get("leaders.enabled"), false);
     offsetTop: site.get("leaders.offsetTop", 105),
     promotionLimit: site.get("leaders.promotionLimit", 3),
     videoLimit: site.get("leaders.videoLimit", 2),
-    viewAllHref: '/leaders',
+    viewAllHref: "/leaders",
     useContentPrimarySection: true,
     mediaQueries: [
       { prop: "displayCallout", value: true, query: "(min-width: 701px)" },

--- a/packages/leaders/components/home-page.marko
+++ b/packages/leaders/components/home-page.marko
@@ -15,7 +15,7 @@ $ const enabled = defaultValue(site.get("leaders.enabled"), false);
     offsetTop: site.get("leaders.offsetTop", 105),
     promotionLimit: site.get("leaders.promotionLimit", 3),
     videoLimit: site.get("leaders.videoLimit", 2),
-    viewAllHref: '/leaders',
+    viewAllHref: "/leaders",
     mediaQueries: [
       { prop: "open", value: "right", query: "(min-width: 1250px)" },
       { prop: "columns", value: 2, query: "(min-width: 700px)" },

--- a/packages/leaders/templates/leaders.marko
+++ b/packages/leaders/templates/leaders.marko
@@ -37,7 +37,7 @@ $ const { id, alias, name, pageNode } = data;
                 ${site.get("leaders.title")}
               </h1>
               <div class="leaders-index-page__description">
-                <p>Welcome to <em>${config.siteName()}"s</em> ${site.get("leaders.title")} program.</p>
+                <p>Welcome to <em>${config.siteName()}'s</em> ${site.get("leaders.title")} program.</p>
               </div>
             </div>
           </div>

--- a/packages/leaders/templates/leaders.marko
+++ b/packages/leaders/templates/leaders.marko
@@ -37,7 +37,7 @@ $ const { id, alias, name, pageNode } = data;
                 ${site.get("leaders.title")}
               </h1>
               <div class="leaders-index-page__description">
-                <p>Welcome to <em>${config.siteName()}'s</em> ${site.get("leaders.title")} program.</p>
+                <p>Welcome to <em>${config.siteName()}"s</em> ${site.get("leaders.title")} program.</p>
               </div>
             </div>
           </div>

--- a/packages/refresh-theme/components/blocks/content-infinite-scroll.marko
+++ b/packages/refresh-theme/components/blocks/content-infinite-scroll.marko
@@ -1,3 +1,4 @@
+import { getAsObject } from "@base-cms/object-path";
 import defaultValue from "@base-cms/marko-core/utils/default-value";
 import queryFragment from "../../graphql/fragments/content-latest";
 
@@ -87,7 +88,8 @@ $ delete loadMoreQueryParams.queryFragment;
   />
 </marko-web-query>
 
-<refresh-theme-latest-content-load-more-block max-pages=4 native-x=input.nativeX>
+$ const nativeX = getAsObject(input, "nativeXLoadMore");
+<refresh-theme-latest-content-load-more-block max-pages=4 native-x=nativeX>
   <@query
     name=attrs.queryName
     params=loadMoreQueryParams

--- a/packages/refresh-theme/components/blocks/content-infinite-scroll.marko
+++ b/packages/refresh-theme/components/blocks/content-infinite-scroll.marko
@@ -83,10 +83,11 @@ $ delete loadMoreQueryParams.queryFragment;
     nodes=nodes
     with-header=true
     header=attrs.header
+    native-x=input.nativeX
   />
 </marko-web-query>
 
-<refresh-theme-latest-content-load-more-block max-pages=4>
+<refresh-theme-latest-content-load-more-block max-pages=4 native-x=input.nativeX>
   <@query
     name=attrs.queryName
     params=loadMoreQueryParams
@@ -96,5 +97,4 @@ $ delete loadMoreQueryParams.queryFragment;
     ...GAM.getAdUnit({ name: "infinite-interstitial", aliases })
     modifiers=["max-width-300", "margin-auto-x"]
   />
-  <@native-x indices=[0] name="default" aliases=aliases />
 </refresh-theme-latest-content-load-more-block>

--- a/packages/refresh-theme/components/blocks/content-infinite-scroll.marko
+++ b/packages/refresh-theme/components/blocks/content-infinite-scroll.marko
@@ -96,5 +96,5 @@ $ delete loadMoreQueryParams.queryFragment;
     ...GAM.getAdUnit({ name: "infinite-interstitial", aliases })
     modifiers=["max-width-300", "margin-auto-x"]
   />
-  <@native-x index=0 name="default" aliases=aliases />
+  <@native-x indices=[0] name="default" aliases=aliases />
 </refresh-theme-latest-content-load-more-block>

--- a/packages/refresh-theme/components/blocks/marko.json
+++ b/packages/refresh-theme/components/blocks/marko.json
@@ -5,10 +5,7 @@
     "<page>": {},
     "<adunit>": {},
     "<native-x>": {
-      "@indices": {
-        "type": "array",
-        "default-value": [0]
-      },
+      "@indices": "array",
       "@name": "string",
       "@aliases": "array"
     },
@@ -27,10 +24,7 @@
   "<refresh-theme-recommended-block>": {
     "template": "./recommended.marko",
     "<native-x>": {
-      "@indices": {
-        "type": "array",
-        "default-value": [0]
-      },
+      "@indices": "array",
       "@name": "string",
       "@aliases": "array"
     },
@@ -46,10 +40,7 @@
   "<refresh-theme-latest-in-section-block>": {
     "template": "./latest-in-section.marko",
     "<native-x>": {
-      "@indices": {
-        "type": "array",
-        "default-value": [0]
-      },
+      "@indices": "array",
       "@name": "string",
       "@aliases": "array"
     },
@@ -60,18 +51,12 @@
   "<refresh-theme-content-infinite-scroll-block>": {
     "template":  "./content-infinite-scroll.marko",
     "<native-x>": {
-      "@indices": {
-        "type": "array",
-        "default-value": []
-      },
+      "@indices": "array",
       "@name": "string",
       "@aliases": "array"
     },
     "<native-x-load-more>": {
-      "@indices": {
-        "type": "array",
-        "default-value": [0]
-      },
+      "@indices": "array",
       "@name": "string",
       "@aliases": "array"
     },

--- a/packages/refresh-theme/components/blocks/marko.json
+++ b/packages/refresh-theme/components/blocks/marko.json
@@ -5,7 +5,7 @@
     "<page>": {},
     "<adunit>": {},
     "<native-x>": {
-      "@indices": "array",
+      "@indexes": "array",
       "@name": "string",
       "@aliases": "array"
     },
@@ -24,7 +24,7 @@
   "<refresh-theme-recommended-block>": {
     "template": "./recommended.marko",
     "<native-x>": {
-      "@indices": "array",
+      "@indexes": "array",
       "@name": "string",
       "@aliases": "array"
     },
@@ -40,7 +40,7 @@
   "<refresh-theme-latest-in-section-block>": {
     "template": "./latest-in-section.marko",
     "<native-x>": {
-      "@indices": "array",
+      "@indexes": "array",
       "@name": "string",
       "@aliases": "array"
     },
@@ -51,12 +51,12 @@
   "<refresh-theme-content-infinite-scroll-block>": {
     "template":  "./content-infinite-scroll.marko",
     "<native-x>": {
-      "@indices": "array",
+      "@indexes": "array",
       "@name": "string",
       "@aliases": "array"
     },
     "<native-x-load-more>": {
-      "@indices": "array",
+      "@indexes": "array",
       "@name": "string",
       "@aliases": "array"
     },

--- a/packages/refresh-theme/components/blocks/marko.json
+++ b/packages/refresh-theme/components/blocks/marko.json
@@ -59,6 +59,14 @@
   },
   "<refresh-theme-content-infinite-scroll-block>": {
     "template":  "./content-infinite-scroll.marko",
+    "<native-x>": {
+      "@indices": {
+        "type": "array",
+        "default-value": [0]
+      },
+      "@name": "string",
+      "@aliases": "array"
+    },
     "@id": "number",
     "@type": "string",
     "@name": "string",

--- a/packages/refresh-theme/components/blocks/marko.json
+++ b/packages/refresh-theme/components/blocks/marko.json
@@ -62,6 +62,14 @@
     "<native-x>": {
       "@indices": {
         "type": "array",
+        "default-value": []
+      },
+      "@name": "string",
+      "@aliases": "array"
+    },
+    "<native-x-load-more>": {
+      "@indices": {
+        "type": "array",
         "default-value": [0]
       },
       "@name": "string",

--- a/packages/refresh-theme/components/blocks/marko.json
+++ b/packages/refresh-theme/components/blocks/marko.json
@@ -5,7 +5,10 @@
     "<page>": {},
     "<adunit>": {},
     "<native-x>": {
-      "@index": "number",
+      "@indices": {
+        "type": "array",
+        "default-value": [0]
+      },
       "@name": "string",
       "@aliases": "array"
     },
@@ -24,7 +27,10 @@
   "<refresh-theme-recommended-block>": {
     "template": "./recommended.marko",
     "<native-x>": {
-      "@index": "number",
+      "@indices": {
+        "type": "array",
+        "default-value": [0]
+      },
       "@name": "string",
       "@aliases": "array"
     },
@@ -40,7 +46,10 @@
   "<refresh-theme-latest-in-section-block>": {
     "template": "./latest-in-section.marko",
     "<native-x>": {
-      "@index": "number",
+      "@indices": {
+        "type": "array",
+        "default-value": [0]
+      },
       "@name": "string",
       "@aliases": "array"
     },

--- a/packages/refresh-theme/components/flows/content-card-deck.marko
+++ b/packages/refresh-theme/components/flows/content-card-deck.marko
@@ -5,32 +5,24 @@ $ const { nativeX: nxConfig } = out.global;
 $ const nativeX = getAsObject(input, "nativeX");
 $ const image = getAsObject(input, "node.image");
 
-<default-theme-card-deck-flow
-  tag=input.tag
-  class=input.class
-  modifiers=input.modifiers
-  attrs=input.attrs
-  cols=defaultValue(input.cols, 3)
-  nodes=input.nodes
->
-  <@slot|{ node, index }|>
-    <marko-web-native-x-render|{ node: nxNode, linkAttrs, containerAttrs }|
-      ...nativeX
-      when=(index === nativeX.index)
-      node=node
-      config=nxConfig
-    >
+<refresh-theme-native-x-inject|{ nodes: injected }| nodes=input.nodes ...nativeX config=nxConfig>
+  <default-theme-card-deck-flow
+    tag=input.tag
+    class=input.class
+    modifiers=input.modifiers
+    attrs=input.attrs
+    cols=defaultValue(input.cols, 3)
+    nodes=injected
+  >
+    <@slot|{ node, index }|>
       <refresh-theme-content-card-node
         ...input.node
-        node=nxNode
-        attrs=containerAttrs
-        link-attrs=linkAttrs
+        node=node
+        attrs=getAsObject(node, "attributes.container")
+        link-attrs=getAsObject(node, "attributes.link")
       >
-        <@image
-          width=340
-          ...image
-        />
+        <@image width=340 ...image />
       </refresh-theme-content-card-node>
-    </marko-web-native-x-render>
-  </@slot>
-</default-theme-card-deck-flow>
+    </@slot>
+  </default-theme-card-deck-flow>
+</refresh-theme-native-x-inject>

--- a/packages/refresh-theme/components/flows/content-list.marko
+++ b/packages/refresh-theme/components/flows/content-list.marko
@@ -5,29 +5,24 @@ $ const { nativeX: nxConfig } = out.global;
 $ const nodes = getAsArray(input, "nodes");
 $ const nativeX = getAsObject(input, "nativeX");
 
-<marko-web-node-list
-  inner-justified=defaultValue(input.innerJustified, true)
-  class=input.class
-  flush-x=defaultValue(input.flushX, true)
-  flush-y=defaultValue(input.flushY, true)
-  modifiers=input.modifiers
-  header=input.header
->
-  <@nodes nodes=nodes>
-    <@slot|{ node, index }|>
-      <marko-web-native-x-render|{ node: nxNode, linkAttrs, containerAttrs }|
-        ...nativeX
-        when=(index === nativeX.index)
-        node=node
-        config=nxConfig
-      >
+<refresh-theme-native-x-inject|{ nodes: injected }| nodes=nodes ...nativeX config=nxConfig>
+  <marko-web-node-list
+    inner-justified=defaultValue(input.innerJustified, true)
+    class=input.class
+    flush-x=defaultValue(input.flushX, true)
+    flush-y=defaultValue(input.flushY, true)
+    modifiers=input.modifiers
+    header=input.header
+  >
+    <@nodes nodes=injected>
+      <@slot|{ node, index }|>
         <refresh-theme-content-list-node
           ...input.node
-          node=nxNode
-          attrs=containerAttrs
-          link-attrs=linkAttrs
+          node=node
+          attrs=getAsObject(node, "attributes.container")
+          link-attrs=getAsObject(node, "attributes.link")
         />
-      </marko-web-native-x-render>
-    </@slot>
-  </@nodes>
-</marko-web-node-list>
+      </@slot>
+    </@nodes>
+  </marko-web-node-list>
+</refresh-theme-native-x-inject>

--- a/packages/refresh-theme/components/flows/marko.json
+++ b/packages/refresh-theme/components/flows/marko.json
@@ -6,7 +6,7 @@
       "<title>": {}
     },
     "<native-x>": {
-      "@indices": "array",
+      "@indexes": "array",
       "@name": "string",
       "@aliases": "array"
     },
@@ -21,7 +21,7 @@
     "template": "./content-hero.marko",
     "<list>": {},
     "<native-x>": {
-      "@indices": "array",
+      "@indexes": "array",
       "@name": "string",
       "@aliases": "array"
     },
@@ -35,7 +35,7 @@
       "<title>": {}
     },
     "<native-x>": {
-      "@indices": "array",
+      "@indexes": "array",
       "@name": "string",
       "@aliases": "array"
     },
@@ -50,7 +50,7 @@
     "template": "./latest-content-list.marko",
     "<adunit>": {},
     "<native-x>": {
-      "@indices": "array",
+      "@indexes": "array",
       "@name": "string",
       "@aliases": "array"
     },

--- a/packages/refresh-theme/components/flows/marko.json
+++ b/packages/refresh-theme/components/flows/marko.json
@@ -6,10 +6,7 @@
       "<title>": {}
     },
     "<native-x>": {
-      "@indices": {
-        "type": "array",
-        "default-value": [0]
-      },
+      "@indices": "array",
       "@name": "string",
       "@aliases": "array"
     },
@@ -24,10 +21,7 @@
     "template": "./content-hero.marko",
     "<list>": {},
     "<native-x>": {
-      "@indices": {
-        "type": "array",
-        "default-value": [0]
-      },
+      "@indices": "array",
       "@name": "string",
       "@aliases": "array"
     },
@@ -41,10 +35,7 @@
       "<title>": {}
     },
     "<native-x>": {
-      "@indices": {
-        "type": "array",
-        "default-value": [0]
-      },
+      "@indices": "array",
       "@name": "string",
       "@aliases": "array"
     },
@@ -59,10 +50,7 @@
     "template": "./latest-content-list.marko",
     "<adunit>": {},
     "<native-x>": {
-      "@indices": {
-        "type": "array",
-        "default-value": [0]
-      },
+      "@indices": "array",
       "@name": "string",
       "@aliases": "array"
     },

--- a/packages/refresh-theme/components/flows/marko.json
+++ b/packages/refresh-theme/components/flows/marko.json
@@ -6,7 +6,10 @@
       "<title>": {}
     },
     "<native-x>": {
-      "@index": "number",
+      "@indices": {
+        "type": "array",
+        "default-value": [0]
+      },
       "@name": "string",
       "@aliases": "array"
     },
@@ -21,7 +24,10 @@
     "template": "./content-hero.marko",
     "<list>": {},
     "<native-x>": {
-      "@index": "number",
+      "@indices": {
+        "type": "array",
+        "default-value": [0]
+      },
       "@name": "string",
       "@aliases": "array"
     },
@@ -35,7 +41,10 @@
       "<title>": {}
     },
     "<native-x>": {
-      "@index": "number",
+      "@indices": {
+        "type": "array",
+        "default-value": [0]
+      },
       "@name": "string",
       "@aliases": "array"
     },
@@ -50,7 +59,10 @@
     "template": "./latest-content-list.marko",
     "<adunit>": {},
     "<native-x>": {
-      "@index": "number",
+      "@indices": {
+        "type": "array",
+        "default-value": [0]
+      },
       "@name": "string",
       "@aliases": "array"
     },

--- a/packages/refresh-theme/components/gam-media-fuse.marko
+++ b/packages/refresh-theme/components/gam-media-fuse.marko
@@ -7,11 +7,11 @@ $ const { id } = input;
       var id = ${id},
       dayMs = 864e5,
       cb = parseInt(Date.now() / dayMs),
-      vpbSrc = 'https://player.mediafuse.com/prebid/wrapper_hb_302826_' + id + '.js?cb=' + cb,
-      gptSrc = 'https://securepubads.g.doubleclick.net/tag/js/gpt.js',
+      vpbSrc = "https://player.mediafuse.com/prebid/wrapper_hb_302826_" + id + ".js?cb=" + cb,
+      gptSrc = "https://securepubads.g.doubleclick.net/tag/js/gpt.js",
       c = d.head || d.body || d.documentElement;
       function loadScript(src, cb) {
-        var s = d.createElement('script');
+        var s = d.createElement("script");
         s.src = src; c.appendChild(s);
         s.onload = cb;
         s.onerror = cb;

--- a/packages/refresh-theme/components/marko.json
+++ b/packages/refresh-theme/components/marko.json
@@ -10,7 +10,7 @@
   "<refresh-theme-native-x-inject>": {
     "template": "./native-x-inject.marko",
     "@limit": "number",
-    "@indices": "array",
+    "@indexes": "array",
     "@index": "number",
     "@name": "string",
     "@section-name": "string",

--- a/packages/refresh-theme/components/marko.json
+++ b/packages/refresh-theme/components/marko.json
@@ -7,6 +7,17 @@
     "./nodes/marko.json",
     "./parse.ly/marko.json"
   ],
+  "<refresh-theme-native-x-inject>": {
+    "template": "./native-x-inject.marko",
+    "@limit": "number",
+    "@indices": "array",
+    "@index": "number",
+    "@name": "string",
+    "@section-name": "string",
+    "@aliases": "array",
+    "@nodes": "array",
+    "@config": "object"
+  },
   "<refresh-theme-document>": {
     "template": "./document.marko",
     "<head>": {},

--- a/packages/refresh-theme/components/native-x-inject.marko
+++ b/packages/refresh-theme/components/native-x-inject.marko
@@ -17,8 +17,8 @@ $ const opts = { ...placement.opts, n: adsToRequest };
 $ let n = 0;
 
 $ const injectAds = (nodes, ads) => nodes.map((node, i) => {
-  if (!indices.includes(i) || !ads[n] || !ads[n].hasCampaign) return node;
   const ad = ads[n];
+  if (!indices.includes(i) || !ad || !ad.hasCampaign) return node;
   n += 1;
   return { ...convert(ad, { sectionName }), attributes: ad.attributes };
 });

--- a/packages/refresh-theme/components/native-x-inject.marko
+++ b/packages/refresh-theme/components/native-x-inject.marko
@@ -16,7 +16,7 @@ $ const opts = { ...placement.opts, n: num };
 $ let n = 0;
 
 $ const injectAds = (nodes, ads) => nodes.map((node, i) => {
-  if (!indices.includes(i) || !ads[n]) return node;
+  if (!indices.includes(i) || !ads[n] || !ads[n].hasCampaign) return node;
   const ad = ads[n];
   n++;
   return { ...convert(ad, { sectionName }), attributes: ad.attributes };

--- a/packages/refresh-theme/components/native-x-inject.marko
+++ b/packages/refresh-theme/components/native-x-inject.marko
@@ -15,12 +15,11 @@ $ const num = indices.length;
 $ const { uri, id } = placement;
 $ const opts = { ...placement.opts, n: num };
 $ let n = 0;
-$ console.log('inject', { indices, placement });
 
 $ const injectAds = (nodes, ads) => nodes.map((node, i) => {
   if (!indices.includes(i) || !ads[n] || !ads[n].hasCampaign) return node;
   const ad = ads[n];
-  n++;
+  n += 1;
   return { ...convert(ad, { sectionName }), attributes: ad.attributes };
 });
 

--- a/packages/refresh-theme/components/native-x-inject.marko
+++ b/packages/refresh-theme/components/native-x-inject.marko
@@ -9,7 +9,7 @@ $ const {
   sectionName,
 } = input;
 $ const indices = defaultValue(input.indices, [0]);
-$ const nodes = getAsArray(input, 'nodes');
+$ const nodes = getAsArray(input, "nodes");
 $ const placement = config.getPlacement({ name, aliases });
 $ const num = indices.length;
 $ const { uri, id } = placement;

--- a/packages/refresh-theme/components/native-x-inject.marko
+++ b/packages/refresh-theme/components/native-x-inject.marko
@@ -1,0 +1,35 @@
+import { getAsArray } from "@base-cms/object-path";
+import convert from "@base-cms/marko-web-native-x/utils/convert-ad-to-content";
+
+$ const {
+  config,
+  name,
+  aliases,
+  sectionName,
+} = input;
+$ const indices = getAsArray(input, 'indices');
+$ const nodes = getAsArray(input, 'nodes');
+$ if (!indices.length && typeof input.index !== 'undefined') {
+  indices.push(input.index);
+}
+$ const placement = config.getPlacement({ name, aliases });
+$ const num = indices.length;
+$ const { uri, id } = placement;
+$ const opts = { ...placement.opts, n: num };
+$ let n = 0;
+
+$ const injectAds = (nodes, ads) => nodes.map((node, i) => {
+  if (!indices.includes(i) || !ads[n]) return node;
+  const ad = ads[n];
+  n++;
+  return { ...convert(ad, { sectionName }), attributes: ad.attributes };
+});
+
+<if(config && num > 0 && uri && id)>
+  <marko-web-native-x-fetch-elements|{ ads }| uri=uri id=id opts=opts>
+    <${input.renderBody} nodes=injectAds(nodes, ads) />
+  </marko-web-native-x-fetch-elements>
+</if>
+<else>
+  <${input.renderBody} nodes=nodes />
+</else>

--- a/packages/refresh-theme/components/native-x-inject.marko
+++ b/packages/refresh-theme/components/native-x-inject.marko
@@ -9,9 +9,6 @@ $ const {
 } = input;
 $ const indices = getAsArray(input, 'indices');
 $ const nodes = getAsArray(input, 'nodes');
-$ if (!indices.length && typeof input.index !== 'undefined') {
-  indices.push(input.index);
-}
 $ const placement = config.getPlacement({ name, aliases });
 $ const num = indices.length;
 $ const { uri, id } = placement;

--- a/packages/refresh-theme/components/native-x-inject.marko
+++ b/packages/refresh-theme/components/native-x-inject.marko
@@ -8,17 +8,17 @@ $ const {
   aliases,
   sectionName,
 } = input;
-$ const indices = defaultValue(input.indices, [0]);
+$ const indexes = defaultValue(input.indexes, [0]);
 $ const nodes = getAsArray(input, "nodes");
 $ const placement = config.getPlacement({ name, aliases });
-$ const adsToRequest = indices.length;
+$ const adsToRequest = indexes.length;
 $ const { uri, id } = placement;
 $ const opts = { ...placement.opts, n: adsToRequest };
 $ let n = 0;
 
 $ const injectAds = (nodes, ads) => nodes.map((node, i) => {
   const ad = ads[n];
-  if (!indices.includes(i) || !ad || !ad.hasCampaign) return node;
+  if (!indexes.includes(i) || !ad || !ad.hasCampaign) return node;
   n += 1;
   return { ...convert(ad, { sectionName }), attributes: ad.attributes };
 });

--- a/packages/refresh-theme/components/native-x-inject.marko
+++ b/packages/refresh-theme/components/native-x-inject.marko
@@ -1,4 +1,5 @@
 import { getAsArray } from "@base-cms/object-path";
+import defaultValue from "@base-cms/marko-core/utils/default-value";
 import convert from "@base-cms/marko-web-native-x/utils/convert-ad-to-content";
 
 $ const {
@@ -7,13 +8,14 @@ $ const {
   aliases,
   sectionName,
 } = input;
-$ const indices = getAsArray(input, 'indices');
+$ const indices = defaultValue(input.indices, [0]);
 $ const nodes = getAsArray(input, 'nodes');
 $ const placement = config.getPlacement({ name, aliases });
 $ const num = indices.length;
 $ const { uri, id } = placement;
 $ const opts = { ...placement.opts, n: num };
 $ let n = 0;
+$ console.log('inject', { indices, placement });
 
 $ const injectAds = (nodes, ads) => nodes.map((node, i) => {
   if (!indices.includes(i) || !ads[n] || !ads[n].hasCampaign) return node;

--- a/packages/refresh-theme/components/native-x-inject.marko
+++ b/packages/refresh-theme/components/native-x-inject.marko
@@ -11,9 +11,9 @@ $ const {
 $ const indices = defaultValue(input.indices, [0]);
 $ const nodes = getAsArray(input, "nodes");
 $ const placement = config.getPlacement({ name, aliases });
-$ const num = indices.length;
+$ const adsToRequest = indices.length;
 $ const { uri, id } = placement;
-$ const opts = { ...placement.opts, n: num };
+$ const opts = { ...placement.opts, n: adsToRequest };
 $ let n = 0;
 
 $ const injectAds = (nodes, ads) => nodes.map((node, i) => {
@@ -23,7 +23,7 @@ $ const injectAds = (nodes, ads) => nodes.map((node, i) => {
   return { ...convert(ad, { sectionName }), attributes: ad.attributes };
 });
 
-<if(config && num > 0 && uri && id)>
+<if(config && adsToRequest > 0 && uri && id)>
   <marko-web-native-x-fetch-elements|{ ads }| uri=uri id=id opts=opts>
     <${input.renderBody} nodes=injectAds(nodes, ads) />
   </marko-web-native-x-fetch-elements>

--- a/packages/refresh-theme/templates/content/index.marko
+++ b/packages/refresh-theme/templates/content/index.marko
@@ -223,7 +223,7 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
                 section-id=section.id
                 section-name=section.name
               >
-                <@native-x index=0 name="default" aliases=aliases />
+                <@native-x indices=[0] name="default" aliases=aliases />
               </refresh-theme-latest-in-section-block>
 
               <leaders-contextual content-id=id />
@@ -247,7 +247,7 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
         <if(displayRecommended)>
           <@section modifiers=["card-deck"]>
             <refresh-theme-recommended-block>
-              <@native-x index=2 name="default" aliases=aliases />
+              <@native-x indices=[2] name="default" aliases=aliases />
             </refresh-theme-recommended-block>
           </@section>
         </if>

--- a/packages/refresh-theme/templates/content/index.marko
+++ b/packages/refresh-theme/templates/content/index.marko
@@ -225,7 +225,7 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
                 section-name=section.name
               >
                 <@native-x
-                  indices=defaultValue(site.get("nativeX.content.latestIn.indices"), [0])
+                  indexes=defaultValue(site.get("nativeX.content.latestIn.indexes"), [0])
                   name="default"
                   aliases=aliases
                 />
@@ -252,7 +252,7 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
         <if(displayRecommended)>
           <@section modifiers=["card-deck"]>
             <refresh-theme-recommended-block>
-              <@native-x indices=[2] name="default" aliases=aliases />
+              <@native-x indexes=[2] name="default" aliases=aliases />
             </refresh-theme-recommended-block>
           </@section>
         </if>
@@ -293,12 +293,12 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
                   skip=(["company", "contact"].includes(type) ? 0 : 4)
                 >
                   <@native-x
-                    indices=defaultValue(site.get("nativeX.content.latest.initial.indices"), [])
+                    indexes=defaultValue(site.get("nativeX.content.latest.initial.indexes"), [])
                     name="default"
                     aliases=aliases
                   />
                   <@native-x-load-more
-                    indices=defaultValue(site.get("nativeX.content.latest.loadMore.indices"), [0])
+                    indexes=defaultValue(site.get("nativeX.content.latest.loadMore.indexes"), [0])
                     name="default"
                     aliases=aliases
                   />

--- a/packages/refresh-theme/templates/content/index.marko
+++ b/packages/refresh-theme/templates/content/index.marko
@@ -1,4 +1,5 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
+import defaultValue from "@base-cms/marko-core/utils/default-value";
 import { getAsObject, get } from "@base-cms/object-path";
 import queryFragment from "../../graphql/fragments/content-list";
 
@@ -218,7 +219,7 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
                 slots=adSlots({ aliases })
               />
 
-              $ const latestIn = site.get('nativeX.content.latestIn.indices') || [0];
+              $ const latestIn = defaultValue(site.get('nativeX.content.latestIn.indices'), [0]);
               <refresh-theme-latest-in-section-block
                 content-id=id
                 section-id=section.id
@@ -279,8 +280,8 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
           <@section>
             <div class="row">
               <div class="col-lg-8 infinite-scroll-target">
-                $ const scrollInitial = site.get('nativeX.content.latest.initial.indices') || [];
-                $ const scrollMore = site.get('nativeX.content.latest.loadMore.indices') || [0];
+                $ const scrollInitial = defaultValue(site.get('nativeX.content.latest.initial.indices'), []);
+                $ const scrollMore = defaultValue(site.get('nativeX.content.latest.loadMore.indices'), [0]);
                 <refresh-theme-content-infinite-scroll-block
                   id=id
                   type=type

--- a/packages/refresh-theme/templates/content/index.marko
+++ b/packages/refresh-theme/templates/content/index.marko
@@ -219,13 +219,16 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
                 slots=adSlots({ aliases })
               />
 
-              $ const latestIn = defaultValue(site.get("nativeX.content.latestIn.indices"), [0]);
               <refresh-theme-latest-in-section-block
                 content-id=id
                 section-id=section.id
                 section-name=section.name
               >
-                <@native-x indices=latestIn name="default" aliases=aliases />
+                <@native-x
+                  indices=defaultValue(site.get("nativeX.content.latestIn.indices"), [0])
+                  name="default"
+                  aliases=aliases
+                />
               </refresh-theme-latest-in-section-block>
 
               <leaders-contextual content-id=id />
@@ -280,8 +283,6 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
           <@section>
             <div class="row">
               <div class="col-lg-8 infinite-scroll-target">
-                $ const scrollInitial = defaultValue(site.get("nativeX.content.latest.initial.indices"), []);
-                $ const scrollMore = defaultValue(site.get("nativeX.content.latest.loadMore.indices"), [0]);
                 <refresh-theme-content-infinite-scroll-block
                   id=id
                   type=type
@@ -291,8 +292,16 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
                   limit=12
                   skip=(["company", "contact"].includes(type) ? 0 : 4)
                 >
-                  <@native-x indices=scrollInitial name="default" aliases=aliases />
-                  <@native-x-load-more indices=scrollMore name="default" aliases=aliases />
+                  <@native-x
+                    indices=defaultValue(site.get("nativeX.content.latest.initial.indices"), [])
+                    name="default"
+                    aliases=aliases
+                  />
+                  <@native-x-load-more
+                    indices=defaultValue(site.get("nativeX.content.latest.loadMore.indices"), [0])
+                    name="default"
+                    aliases=aliases
+                  />
                 </refresh-theme-content-infinite-scroll-block>
               </div>
               <aside class="col-lg-4 page-rail">

--- a/packages/refresh-theme/templates/content/index.marko
+++ b/packages/refresh-theme/templates/content/index.marko
@@ -218,13 +218,13 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
                 slots=adSlots({ aliases })
               />
 
-              $ const latestIndices = site.get('nativeX.content.latest-in.indices') || [0];
+              $ const latestIn = site.get('nativeX.content.latestIn.indices') || [0];
               <refresh-theme-latest-in-section-block
                 content-id=id
                 section-id=section.id
                 section-name=section.name
               >
-                <@native-x indices=latestIndices name="default" aliases=aliases />
+                <@native-x indices=latestIn name="default" aliases=aliases />
               </refresh-theme-latest-in-section-block>
 
               <leaders-contextual content-id=id />
@@ -279,7 +279,8 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
           <@section>
             <div class="row">
               <div class="col-lg-8 infinite-scroll-target">
-                $ const scrollIndices = site.get('nativeX.content.load-more.indices') || [];
+                $ const scrollInitial = site.get('nativeX.content.latest.initial.indices') || [];
+                $ const scrollMore = site.get('nativeX.content.latest.loadMore.indices') || [0];
                 <refresh-theme-content-infinite-scroll-block
                   id=id
                   type=type
@@ -289,7 +290,8 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
                   limit=12
                   skip=(["company", "contact"].includes(type) ? 0 : 4)
                 >
-                  <@native-x indices=scrollIndices name="default" aliases=aliases />
+                  <@native-x indices=scrollInitial name="default" aliases=aliases />
+                  <@native-x-load-more indices=scrollMore name="default" aliases=aliases />
                 </refresh-theme-content-infinite-scroll-block>
               </div>
               <aside class="col-lg-4 page-rail">

--- a/packages/refresh-theme/templates/content/index.marko
+++ b/packages/refresh-theme/templates/content/index.marko
@@ -133,7 +133,7 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
                   <marko-web-page-image
                     obj=content.primaryImage
                     modifiers=["fluid-16by9"]
-                    options={ w: 512, h: 288, fit: 'crop' }
+                    options={ w: 512, h: 288, fit: "crop" }
                   />
                 </else>
               </else-if>
@@ -219,7 +219,7 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
                 slots=adSlots({ aliases })
               />
 
-              $ const latestIn = defaultValue(site.get('nativeX.content.latestIn.indices'), [0]);
+              $ const latestIn = defaultValue(site.get("nativeX.content.latestIn.indices"), [0]);
               <refresh-theme-latest-in-section-block
                 content-id=id
                 section-id=section.id
@@ -280,8 +280,8 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
           <@section>
             <div class="row">
               <div class="col-lg-8 infinite-scroll-target">
-                $ const scrollInitial = defaultValue(site.get('nativeX.content.latest.initial.indices'), []);
-                $ const scrollMore = defaultValue(site.get('nativeX.content.latest.loadMore.indices'), [0]);
+                $ const scrollInitial = defaultValue(site.get("nativeX.content.latest.initial.indices"), []);
+                $ const scrollMore = defaultValue(site.get("nativeX.content.latest.loadMore.indices"), [0]);
                 <refresh-theme-content-infinite-scroll-block
                   id=id
                   type=type

--- a/packages/refresh-theme/templates/content/index.marko
+++ b/packages/refresh-theme/templates/content/index.marko
@@ -218,12 +218,13 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
                 slots=adSlots({ aliases })
               />
 
+              $ const latestIndices = site.get('nativeX.content.latest-in.indices') || [0];
               <refresh-theme-latest-in-section-block
                 content-id=id
                 section-id=section.id
                 section-name=section.name
               >
-                <@native-x indices=[0] name="default" aliases=aliases />
+                <@native-x indices=latestIndices name="default" aliases=aliases />
               </refresh-theme-latest-in-section-block>
 
               <leaders-contextual content-id=id />
@@ -278,6 +279,7 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
           <@section>
             <div class="row">
               <div class="col-lg-8 infinite-scroll-target">
+                $ const scrollIndices = site.get('nativeX.content.load-more.indices') || [];
                 <refresh-theme-content-infinite-scroll-block
                   id=id
                   type=type
@@ -286,7 +288,9 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
                   aliases=aliases
                   limit=12
                   skip=(["company", "contact"].includes(type) ? 0 : 4)
-                />
+                >
+                  <@native-x indices=scrollIndices name="default" aliases=aliases />
+                </refresh-theme-content-infinite-scroll-block>
               </div>
               <aside class="col-lg-4 page-rail">
                 <refresh-theme-follow-us-block />

--- a/packages/refresh-theme/templates/index.marko
+++ b/packages/refresh-theme/templates/index.marko
@@ -82,7 +82,7 @@ $ const adSlots = ({ aliases }) => ({
 
         <@section modifiers=["card-deck"]>
           <refresh-theme-recommended-block>
-            <@native-x indices=[2] name="default" aliases=aliases />
+            <@native-x indexes=[2] name="default" aliases=aliases />
           </refresh-theme-recommended-block>
         </@section>
 
@@ -172,7 +172,7 @@ $ const adSlots = ({ aliases }) => ({
                   params={ excludeContentTypes, limit: 12, skip: 6, requiresImage: true, queryFragment: latestQueryFragment }
                 >
                   <refresh-theme-latest-content-list-flow nodes=nodes with-header=false>
-                    <@native-x indices=[0] name="default" aliases=aliases />
+                    <@native-x indexes=[0] name="default" aliases=aliases />
                   </refresh-theme-latest-content-list-flow>
                 </marko-web-query>
 
@@ -186,7 +186,7 @@ $ const adSlots = ({ aliases }) => ({
                     ...GAM.getAdUnit({ name: "infinite-interstitial", aliases })
                     modifiers=["max-width-300", "margin-auto-x"]
                   />
-                  <@native-x indices=[0] name="default" aliases=aliases />
+                  <@native-x indexes=[0] name="default" aliases=aliases />
                 </refresh-theme-latest-content-load-more-block>
               </div>
 

--- a/packages/refresh-theme/templates/index.marko
+++ b/packages/refresh-theme/templates/index.marko
@@ -82,7 +82,7 @@ $ const adSlots = ({ aliases }) => ({
 
         <@section modifiers=["card-deck"]>
           <refresh-theme-recommended-block>
-            <@native-x index=2 name="default" aliases=aliases />
+            <@native-x indices=[2] name="default" aliases=aliases />
           </refresh-theme-recommended-block>
         </@section>
 
@@ -172,7 +172,7 @@ $ const adSlots = ({ aliases }) => ({
                   params={ excludeContentTypes, limit: 12, skip: 6, requiresImage: true, queryFragment: latestQueryFragment }
                 >
                   <refresh-theme-latest-content-list-flow nodes=nodes with-header=false>
-                    <@native-x index=0 name="default" aliases=aliases />
+                    <@native-x indices=[0] name="default" aliases=aliases />
                   </refresh-theme-latest-content-list-flow>
                 </marko-web-query>
 
@@ -186,7 +186,7 @@ $ const adSlots = ({ aliases }) => ({
                     ...GAM.getAdUnit({ name: "infinite-interstitial", aliases })
                     modifiers=["max-width-300", "margin-auto-x"]
                   />
-                  <@native-x index=0 name="default" aliases=aliases />
+                  <@native-x indices=[0] name="default" aliases=aliases />
                 </refresh-theme-latest-content-load-more-block>
               </div>
 

--- a/packages/refresh-theme/templates/website-section/index.marko
+++ b/packages/refresh-theme/templates/website-section/index.marko
@@ -108,7 +108,7 @@ $ const adSlots = ({ aliases }) => ({
 
           <@section modifiers=["card-deck"]>
             <refresh-theme-recommended-block>
-              <@native-x index=2 name="default" aliases=aliases />
+              <@native-x indices=[2] name="default" aliases=aliases />
             </refresh-theme-recommended-block>
           </@section>
 
@@ -192,7 +192,7 @@ $ const adSlots = ({ aliases }) => ({
                     }
                   >
                     <refresh-theme-latest-content-list-flow nodes=nodes with-header=false>
-                      <@native-x index=0 name="default" aliases=aliases />
+                      <@native-x indices=[0] name="default" aliases=aliases />
                     </refresh-theme-latest-content-list-flow>
                   </marko-web-query>
 
@@ -212,7 +212,7 @@ $ const adSlots = ({ aliases }) => ({
                       ...GAM.getAdUnit({ name: "infinite-interstitial", aliases })
                       modifiers=["max-width-300", "margin-auto-x"]
                     />
-                    <@native-x index=0 name="default" aliases=aliases />
+                    <@native-x indices=[0] name="default" aliases=aliases />
                   </refresh-theme-latest-content-load-more-block>
                 </div>
 

--- a/packages/refresh-theme/templates/website-section/index.marko
+++ b/packages/refresh-theme/templates/website-section/index.marko
@@ -108,7 +108,7 @@ $ const adSlots = ({ aliases }) => ({
 
           <@section modifiers=["card-deck"]>
             <refresh-theme-recommended-block>
-              <@native-x indices=[2] name="default" aliases=aliases />
+              <@native-x indexes=[2] name="default" aliases=aliases />
             </refresh-theme-recommended-block>
           </@section>
 
@@ -192,7 +192,7 @@ $ const adSlots = ({ aliases }) => ({
                     }
                   >
                     <refresh-theme-latest-content-list-flow nodes=nodes with-header=false>
-                      <@native-x indices=[0] name="default" aliases=aliases />
+                      <@native-x indexes=[0] name="default" aliases=aliases />
                     </refresh-theme-latest-content-list-flow>
                   </marko-web-query>
 
@@ -212,7 +212,7 @@ $ const adSlots = ({ aliases }) => ({
                       ...GAM.getAdUnit({ name: "infinite-interstitial", aliases })
                       modifiers=["max-width-300", "margin-auto-x"]
                     />
-                    <@native-x indices=[0] name="default" aliases=aliases />
+                    <@native-x indexes=[0] name="default" aliases=aliases />
                   </refresh-theme-latest-content-load-more-block>
                 </div>
 

--- a/sites/foodlogistics.com/config/native-x.js
+++ b/sites/foodlogistics.com/config/native-x.js
@@ -12,11 +12,16 @@ module.exports = {
     'ocean-ports-carriers': '5b56095b2a488f0001ecf2c0',
   },
   content: {
-    'latest-in': {
+    latestIn: {
       indices: [0, 2],
     },
-    'load-more': {
-      indices: [5, 11],
+    latest: {
+      initial: {
+        indices: [5, 11],
+      },
+      loadMore: {
+        indices: [11],
+      },
     },
   },
 };

--- a/sites/foodlogistics.com/config/native-x.js
+++ b/sites/foodlogistics.com/config/native-x.js
@@ -13,14 +13,14 @@ module.exports = {
   },
   content: {
     latestIn: {
-      indices: [0, 2],
+      indexes: [0, 2],
     },
     latest: {
       initial: {
-        indices: [5, 11],
+        indexes: [5, 11],
       },
       loadMore: {
-        indices: [11],
+        indexes: [11],
       },
     },
   },

--- a/sites/foodlogistics.com/config/native-x.js
+++ b/sites/foodlogistics.com/config/native-x.js
@@ -11,4 +11,12 @@ module.exports = {
     'risk-compliance': '5b56094ea4ac010001bbc4f8',
     'ocean-ports-carriers': '5b56095b2a488f0001ecf2c0',
   },
+  content: {
+    'latest-in': {
+      indices: [0, 2],
+    },
+    'load-more': {
+      indices: [5, 11],
+    },
+  },
 };

--- a/sites/sdcexec.com/config/native-x.js
+++ b/sites/sdcexec.com/config/native-x.js
@@ -12,14 +12,14 @@ module.exports = {
   },
   content: {
     latestIn: {
-      indices: [0, 2],
+      indexes: [0, 2],
     },
     latest: {
       initial: {
-        indices: [5, 11],
+        indexes: [5, 11],
       },
       loadMore: {
-        indices: [11],
+        indexes: [11],
       },
     },
   },

--- a/sites/sdcexec.com/config/native-x.js
+++ b/sites/sdcexec.com/config/native-x.js
@@ -10,4 +10,12 @@ module.exports = {
     '3pl-4pl': '5b5609e22a488f0001ecf2c9',
     'professional-development': '5b5609ee2a488f0001ecf2ca',
   },
+  content: {
+    'latest-in': {
+      indices: [0, 2],
+    },
+    'load-more': {
+      indices: [5, 11],
+    },
+  },
 };

--- a/sites/sdcexec.com/config/native-x.js
+++ b/sites/sdcexec.com/config/native-x.js
@@ -11,11 +11,16 @@ module.exports = {
     'professional-development': '5b5609ee2a488f0001ecf2ca',
   },
   content: {
-    'latest-in': {
+    latestIn: {
       indices: [0, 2],
     },
-    'load-more': {
-      indices: [5, 11],
+    latest: {
+      initial: {
+        indices: [5, 11],
+      },
+      loadMore: {
+        indices: [11],
+      },
     },
   },
 };


### PR DESCRIPTION
Request is twofold for SDCE & FL:
- [x] Include a second ad within the `latest-in` block on the content page right-rail
- [x] * Update load more to contain 6 content, 1 ad, 6 content, 1 ad
  - This is implemented as 5 content 1 ad, 5 content 1 ad to keep existing limit/skip logic the same
  - After initial `CCCCCACCCCCA` pattern, the remaining load more calls will be 11 content 1 ad
  - Moving the ad to the end of the load more segment prevents two ads from stacking between load-more 1 & 2.

While this affects the entire refresh theme, the actual content/ad order is driven from site configuration and only affects SDC & FL (confirmed on FCP).

---

![screencapture-0-0-0-0-9711-warehousing-press-release-21195770-ct-realty-ct-realty-breaks-ground-on-major-logistics-center-in-southern-california-2020-09-30-15_44_53](https://user-images.githubusercontent.com/1778222/94740403-39573300-0338-11eb-9487-d5690a875579.png)